### PR TITLE
文件上传时，自动识别文件类型

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ node_modules
 Session.vim
 .netrwhist
 *~
+.idea

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,7 @@
 'use strict';
 var fs = require('fs');
 var querystring = require('querystring');
+var contentType = require('content-type-mime');
 
 var utils = require('./utils');
 var pkg = require('../package.json');
@@ -102,8 +103,13 @@ UPYUN.prototype.uploadFile = function(remotePath, localFile, type, checksum, opt
     var _self = this;
     opts = opts || {};
 
-    // TODO: default type
-    opts['Content-Type'] = type;
+    // if type is null or null string, get file mime content
+    if(type === '' || type === null){
+        opts['Content-Type'] = contentType(localFile);
+        console.log(opts['Content-Type']);
+    }else{
+        opts['Content-Type'] = type;
+    }
     var contentLength = 0;
     checksum = arguments.length > 4 && typeof checksum !== 'function' ? checksum : true;
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "istanbul": "^0.3.2"
   },
   "dependencies": {
+    "content-type-mime": "^1.0.1",
     "upyun-legacy": "~0.4.0"
   }
 }


### PR DESCRIPTION
添加文件 mime类型判断库，https://github.com/shanelau/ContentType

文件上传时，如果type参数为 null 或者为 空字符串，则自动识别mime类型，
